### PR TITLE
Add the Sutton and McCallum CRF tutorial as an optional reading.

### DIFF
--- a/_data/ling506_syllabus.yaml
+++ b/_data/ling506_syllabus.yaml
@@ -117,6 +117,11 @@
       url: http://acl.ldc.upenn.edu/P/P06/P06-1009.pdf
       title: Discriminative Word Alignment with Conditional Random Fields
       optional: false
+    -
+      author: Sutton and McCallum
+      url: http://homepages.inf.ed.ac.uk/csutton/publications/crftut-fnt.pdf
+      title: An Introduction to Conditional Random Fields
+      optional: true
 -
   date: 2014-02-17
   title: Language Models


### PR DESCRIPTION
I figured this would be good to link for people interested in backgrounds on CRFs. I've marked it as optional since I'm not sure if you'd want it to be required reading or not.
