### PR TITLE
Fix a bunch of ACL related links.

### DIFF
--- a/_data/ling506_syllabus.yaml
+++ b/_data/ling506_syllabus.yaml
@@ -137,7 +137,7 @@
     -
       author: Google researchers
       title:  Large Language Models in Machine Translation
-      url: http://acl.ldc.upenn.edu/D/D07/D07-1090.pdf
+      url: http://aclweb.org/anthology/D/D07/D07-1090.pdf
       optional: false
     -
       author: Pauls and Klein
@@ -163,7 +163,7 @@
       title: Chapter 5
     -
       author:   Koehn, Och and Marcu
-      url: http://acl.ldc.upenn.edu/N/N03/N03-1017.pdf
+      url: http://aclweb.org/anthology/N/N03/N03-1017.pdf
       title: Statistical Phrase-Based Translation
       optional: false
 -
@@ -223,7 +223,7 @@
       title: Chapter 9
     -
       author: Och and Ney
-      url: http://acl.ldc.upenn.edu/P/P02/P02-1038.pdf
+      url: http://aclweb.org/anthology/P/P02/P02-1038.pdf
       title: Discriminative Training And Maximum Entropy Models For Statistical Machine Translation
       optional: false
 -
@@ -233,7 +233,7 @@
   reading:
     -
       author: Och
-      url: http://acl.ldc.upenn.edu/acl2003/main/pdfs/Och.pdf
+      url: http://www.aclweb.org/anthology/P03-1021
       title: Minimum Error Rate Training In Statistical Machine Translation
       optional: false
     -
@@ -295,7 +295,7 @@
       optional: false
     -
       author: Heidi Fox
-      url: http://acl.ldc.upenn.edu/W/W02/W02-1039.pdf
+      url: http://aclweb.org/anthology/W/W02/W02-1039.pdf
       title: Phrasal Cohesion and Statistical Machine Translation
       optional: false
 -
@@ -329,12 +329,12 @@
   reading:
     -
       author: Philip Resnik and Noah Smith
-      url: http://acl.ldc.upenn.edu/J/J03/J03-3002.pdf
+      url: http://aclweb.org/anthology/J/J03/J03-3002.pdf
       title: The Web as a Parallel Corpus
       optional: false
     -
       author: Jakob Uszkoreit, Jay Ponte, Ashok Popat, and Moshe Dubiner
-      url: http://acl.ldc.upenn.edu/J/J03/J03-3002.pdf
+      url: http://static.googleusercontent.com/media/research.google.com/en/us/pubs/archive/36580.pdf
       title: Large Scale Parallel Document Mining for Machine Translation
       optional: false
     -


### PR DESCRIPTION
The penn.edu urls for the ACL papers don't seem to be working for me, but
their corresponding aclweb.org/anthology/ urls do.

(This also fixes an erroneous duplicated link.)
